### PR TITLE
check: make the user's duty to init consensus at the next height

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,10 @@ very easy to extend `PrepareRequest` to also include proposed transactions.
 2. NEO has the ability to change the list nodes which verify the block (they are called Validators). This is done through `GetValidators`
 callback which is called at the start of every epoch. In the simple case where validators are constant
 it can return the same value everytime it is called.
-3. `ProcessBlock` is a callback which is called synchronously everytime new block is accepted.
-It can or can not persist block but it MUST update all blockchain state
-so that other callbacks including `CurrentHeight` and `CurrentHash` return new values.
+3. `ProcessBlock` is a callback which is called synchronously every time new block is accepted.
+It can or can not persist block; it also may keep the blockchain state unchanged. dBFT will NOT
+be initialized at the next height by itself to collect the next block until the `InitializeConsensus`
+is called. In other words, it's the caller's responsibility to initialize dBFT at the next height even
+after block collection at the current height. It's also the caller's responsibility to update the
+blockchain state before the next height initialization so that other callbacks including
+`CurrentHeight` and `CurrentHash` return new values.

--- a/check.go
+++ b/check.go
@@ -70,6 +70,7 @@ func (d *DBFT) checkCommit() {
 		zap.Stringer("merkle", d.block.MerkleRoot()),
 		zap.Stringer("prev", d.block.PrevHash()))
 
+	d.blockProcessed = true
 	d.ProcessBlock(d.block)
 
 	// Do not initialize consensus process immediately. It's the caller's duty to

--- a/check.go
+++ b/check.go
@@ -72,7 +72,9 @@ func (d *DBFT) checkCommit() {
 
 	d.ProcessBlock(d.block)
 
-	d.InitializeConsensus(0, d.Timestamp)
+	// Do not initialize consensus process immediately. It's the caller's duty to
+	// start the new block acceptance process and call InitializeConsensus at the
+	// new height.
 }
 
 func (d *DBFT) checkChangeView(view byte) {

--- a/dbft.go
+++ b/dbft.go
@@ -490,6 +490,19 @@ func (d *DBFT) onChangeView(msg payload.ConsensusPayload) {
 }
 
 func (d *DBFT) onCommit(msg payload.ConsensusPayload) {
+	existing := d.CommitPayloads[msg.ValidatorIndex()]
+	if existing != nil {
+		if !existing.Hash().Equals(msg.Hash()) {
+			d.Logger.Warn("rejecting commit due to existing",
+				zap.Uint("validator", uint(msg.ValidatorIndex())),
+				zap.Uint("existing view", uint(existing.ViewNumber())),
+				zap.Uint("view", uint(msg.ViewNumber())),
+				zap.String("existing hash", existing.Hash().StringLE()),
+				zap.String("hash", msg.Hash().StringLE()),
+			)
+		}
+		return
+	}
 	if d.ViewNumber == msg.ViewNumber() {
 		d.Logger.Info("received Commit", zap.Uint("validator", uint(msg.ValidatorIndex())))
 		d.extendTimer(4)

--- a/dbft.go
+++ b/dbft.go
@@ -367,7 +367,7 @@ func (d *DBFT) processMissingTx() {
 
 // createAndCheckBlock is a prepareRequest-level helper that creates and checks
 // the new proposed block, if it's fine it returns true, if something is wrong
-// with it it send a changeView request and returns false. It's only valid to
+// with it, it sends a changeView request and returns false. It's only valid to
 // call it when all transactions for this block are already collected.
 func (d *DBFT) createAndCheckBlock() bool {
 	txx := make([]block.Transaction, 0, len(d.TransactionHashes))

--- a/dbft.go
+++ b/dbft.go
@@ -170,7 +170,7 @@ func (d *DBFT) OnTransaction(tx block.Transaction) {
 
 // OnTimeout advances state machine as if timeout was fired.
 func (d *DBFT) OnTimeout(hv timer.HV) {
-	if d.Context.WatchOnly() {
+	if d.Context.WatchOnly() || d.BlockSent() {
 		return
 	}
 
@@ -242,6 +242,11 @@ func (d *DBFT) OnReceive(msg payload.ConsensusPayload) {
 			Height: msg.Height(),
 			View:   msg.ViewNumber(),
 		}
+	}
+
+	if d.BlockSent() && msg.Type() != payload.RecoveryRequestType {
+		// We've already collected the block, only recovery request must be handled.
+		return
 	}
 
 	switch msg.Type() {


### PR DESCRIPTION
It's OK to notify the user about the block collected and do not change the context's state immediately. The user will handle new block and call `InitializeConsensus` by itself like he already does when the new block comes from the other source (e.g. network/RPC). The consensus won't perform any further actions anyway before the next call to `InitializeContext`. The described way of responsibility distribution leads to clear and predictable behaviour and cleaner user's handlers code.

Moreover (it's not an argument, but yet another valid reason to apply this commit), the C# dBFT plugin does the same thing. It leaves the initialization to the `OnPersistCompleted` callback and does not initialize consensus at the new heigh immediately after Commits checks. See the https://github.com/neo-project/neo-modules/blob/52122bd286b0a9854ded648516bb223a8ecb4d2e/src/DBFTPlugin/Consensus/ConsensusService.Check.cs#L64 and
https://github.com/neo-project/neo-modules/blob/52122bd286b0a9854ded648516bb223a8ecb4d2e/src/DBFTPlugin/Consensus/ConsensusService.cs#L75.

It should be noted that it's still the dBFT's duty to initialize consensus at the next non-zero view (e.g. on collecting M ChangeViews), because it is the direct operation of the consensus algorithm.